### PR TITLE
Fix reference error on ldrs loading component

### DIFF
--- a/components/UI/Spinner.tsx
+++ b/components/UI/Spinner.tsx
@@ -1,6 +1,4 @@
-import { ring } from "ldrs";
-
-ring.register();
+import { useEffect } from "react";
 
 interface SpinnerProps {
   color: string;
@@ -8,6 +6,15 @@ interface SpinnerProps {
 }
 
 export default function Spinner({ color, size }: SpinnerProps) {
+  async function getLoader() {
+    const { ring } = await import("ldrs");
+    ring.register();
+  }
+
+  useEffect(() => {
+    getLoader();
+  }, []);
+
   return (
     <div className="flex h-full w-full items-center justify-center">
       <l-ring size={size} stroke="2" bg-opacity="0%" speed="2" color={color}></l-ring>


### PR DESCRIPTION
Fixes:
- Fixed the HTML: ReferenceError that was caused by registering a web component from ldrs without dynamically importing the module.