### PR TITLE
Fix zod enum requiring wrong value to be passed on employee creation

### DIFF
--- a/components/users/UserCreationForm.tsx
+++ b/components/users/UserCreationForm.tsx
@@ -37,6 +37,7 @@ export default function UserCreationForm() {
 
     if (errors) {
       setErrors(errors);
+      console.log(errors);
       setLoading(false);
       return;
     } else {

--- a/lib/schema/schema.ts
+++ b/lib/schema/schema.ts
@@ -58,7 +58,7 @@ export const createUserSchema: ZodType<CreateUser> = z
       }),
     confirmPassword: z.string().min(8),
 
-    role: z.enum(["User", "Admin"]),
+    role: z.enum(["User", "Employee"]),
   })
   .superRefine(({ password, confirmPassword }, ctx) => {
     // By doing this we can access the password and confirmPassword fields and compare them to each other.


### PR DESCRIPTION
Fixes:
- Fixed the zod.enum() function requiring "Admin" to be the value of the select tag and not Employee.