### PR TITLE
Fix old images being fetched after updating a product

### DIFF
--- a/app/dashboard/products/page.tsx
+++ b/app/dashboard/products/page.tsx
@@ -1,32 +1,7 @@
-import { API_URL } from "@/lib/constants/constants";
-import { getUserToken } from "@/lib/actions/helpers/getUserToken";
 import PageLayoutComp from "@/components/ui/PageLayoutComp";
 import ProductCreationNavigatorButton from "@/components/products/ProductCreationNavigatorButton";
 import ProductsWrapper from "@/components/products/ProductsWrapper";
-import { revalidatePath } from "next/cache";
-
-async function getAllProducts() {
-  revalidatePath("/dashboard/products");
-  const token = await getUserToken();
-
-  try {
-    const res = await fetch(`${API_URL}/v1/Product`, {
-      method: "GET",
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-      cache: "no-cache",
-    });
-
-    const data = await res.json();
-
-    // prettier-ignore
-    return res.ok ? { status: 200, message: "Successfully fetched the products", data } : { status: res.status, message: res.statusText, data: null };
-  } catch (error) {
-    console.error(error);
-    return { status: 500, message: "Internal Server Error", data: null };
-  }
-}
+import { getAllProducts } from "@/lib/actions/products/getProducts";
 
 export default async function ProductsPage() {
   const data = await getAllProducts();

--- a/components/products/ProductCard.tsx
+++ b/components/products/ProductCard.tsx
@@ -15,7 +15,7 @@ export default function ProductCard({ ...product }: Product) {
       return;
     }
 
-    await fetchSingleImage(product.images[0].url, setImage);
+    await fetchSingleImage({ imageURL: product.images[0].url, setImageAsURL: setImage });
   }
 
   useEffect(() => {

--- a/components/products/ProductEditForm.tsx
+++ b/components/products/ProductEditForm.tsx
@@ -70,9 +70,9 @@ export default function ProductEditForm({ ...product }: Product) {
       setFormErrors(errors);
       setLoading(false);
       return;
-    } else {
-      setFormErrors({});
     }
+
+    setFormErrors({});
 
     const formData = new FormData(e.currentTarget);
     formData.append("Id", product.id);
@@ -82,6 +82,7 @@ export default function ProductEditForm({ ...product }: Product) {
 
     if (validate) {
       router.push("/dashboard/products");
+      router.refresh();
     }
 
     setLoading(false);
@@ -156,7 +157,7 @@ export default function ProductEditForm({ ...product }: Product) {
           <div key={url} className="relative h-20 w-20">
             <Image src={url} alt={url} fill />
             <div className="absolute right-1 top-1 rounded-lg">
-              <button onClick={() => removeImage(index)} className="rounded-lg bg-black/60">
+              <button onClick={() => removeImage(index)} type="button" className="rounded-lg bg-black/60">
                 <X size={17} className="text-white opacity-60 duration-200 ease-in-out hover:opacity-100" />
               </button>
             </div>

--- a/components/products/ProductsWrapper.tsx
+++ b/components/products/ProductsWrapper.tsx
@@ -1,7 +1,7 @@
 import ProductCard from "./ProductCard";
 
 interface ProductsWrapperProps {
-  products: Product[];
+  products: Product[] | null;
 }
 
 export default function ProductsWrapper({ products }: ProductsWrapperProps) {

--- a/lib/actions/products/getProducts.ts
+++ b/lib/actions/products/getProducts.ts
@@ -1,0 +1,26 @@
+"use server";
+
+import { API_URL } from "@/lib/constants/constants";
+import { getUserToken } from "../helpers/getUserToken";
+
+export async function getAllProducts() {
+  const token = await getUserToken();
+
+  try {
+    const res = await fetch(`${API_URL}/v1/Product`, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+      cache: "no-cache",
+    });
+
+    const data = await res.json();
+
+    // prettier-ignore
+    return res.ok ? { status: 200, message: "Successfully fetched the products", data: data as Product[] } : { status: res.status, message: res.statusText, data: null };
+  } catch (error) {
+    console.error(error);
+    return { status: 500, message: "Internal Server Error", data: null };
+  }
+}

--- a/lib/schema/schema.ts
+++ b/lib/schema/schema.ts
@@ -82,6 +82,6 @@ export const createProductSchema: ZodType<CreateProduct> = z.object({
     .string()
     .min(8, { message: "Description must be at least 8 characters long" })
     .max(500, { message: "Description is too long" }),
-  price: z.number().positive({ message: "Price must be a positive number" }),
-  stock: z.number().positive({ message: "Stock must be a positive number" }),
+  price: z.number().nonnegative({ message: "Price must be a positive number" }),
+  stock: z.number().nonnegative({ message: "Stock must be a positive number" }),
 });

--- a/lib/utils/fetchImages.ts
+++ b/lib/utils/fetchImages.ts
@@ -1,7 +1,7 @@
 // Since setState functions have to be serialized, using "use client" declaration will throw an error, since this function will only itself be able to be used in a client environment.
 
 // In some cases, when you have to use this function on load, if reactStrictMode is enabled, your images will get dupped.
-// It's because useEffect runs twice in strict mode, and the fetchImagesOnLoad function will run twice, causing the images to be fetched twice..
+// It's because useEffect runs twice in strict mode, and the fetchImagesOnLoad function will run twice, causing the images to be fetched twice.
 
 import { API_URL } from "../constants/constants";
 
@@ -16,6 +16,7 @@ export async function fetchImages({ images, setFiles, setImagesAsURLs }: FetchIm
     images.forEach(async (image) => {
       const res = await fetch(`${API_URL}/v1/Image/${image.url}`, {
         method: "GET",
+        cache: "no-cache",
       });
 
       const data = await res.blob();
@@ -30,10 +31,17 @@ export async function fetchImages({ images, setFiles, setImagesAsURLs }: FetchIm
   }
 }
 
-export async function fetchSingleImage(imageURL: string, setImageAsURL: React.Dispatch<React.SetStateAction<string>>) {
+interface FetchSingleImageProps {
+  imageURL: string;
+  setImageAsURL: React.Dispatch<React.SetStateAction<string>>;
+  setImageAsFile?: React.Dispatch<React.SetStateAction<File>>;
+}
+
+export async function fetchSingleImage({ imageURL, setImageAsURL, setImageAsFile }: FetchSingleImageProps) {
   try {
     const res = await fetch(`${API_URL}/v1/Image/${imageURL}`, {
       method: "GET",
+      cache: "no-cache",
     });
 
     const data = await res.blob();
@@ -41,6 +49,7 @@ export async function fetchSingleImage(imageURL: string, setImageAsURL: React.Di
     const url = URL.createObjectURL(data);
 
     setImageAsURL(url);
+    setImageAsFile && setImageAsFile(file);
   } catch (error) {
     console.error(error);
   }


### PR DESCRIPTION
Fixes:
- Fixed the bug where NextJS cached the previous product payload and didn't re-fetch the product, resulting in requesting a wrong image and therefore failing unless refreshed by the client.