### PR TITLE
Add credential encoding to cut unnecessary calls to the service

### DIFF
--- a/components/auth/PageAuthenticator.tsx
+++ b/components/auth/PageAuthenticator.tsx
@@ -15,9 +15,9 @@ export default async function PageAuthenticator({
   children,
 }: PageAuthenticatorProps) {
   const auth = await getUserAuthStatus();
-  const isAdmin = auth.data?.role.name === "Admin" || auth.data?.role.name === "Employee" ? true : false;
-  const isUser = auth.data?.role.name === "User" ? true : false;
-  const isEmployee = auth.data?.role.name === "Employee" ? true : false;
+  const isAdmin = auth.data?.role.name === "Admin" || auth.data?.role.name === "Employee";
+  const isUser = auth.data?.role.name === "User";
+  const isEmployee = auth.data?.role.name === "Employee";
 
   if (shouldNotAllowEmployee && isEmployee) {
     return redirect(redirectTo);

--- a/components/products/ProductCard.tsx
+++ b/components/products/ProductCard.tsx
@@ -7,7 +7,11 @@ import Image from "next/image";
 import Spinner from "../ui/Spinner";
 import ProductActionsBar from "./ProductActionsBar";
 
-export default function ProductCard({ ...product }: Product) {
+interface ProductCardProps extends Product {
+  hasEditPerms: boolean;
+}
+
+export default function ProductCard({ hasEditPerms, ...product }: ProductCardProps ) {
   const [image, setImage] = useState<string>("");
 
   async function fetchCoverImageOnLoad() {
@@ -28,7 +32,7 @@ export default function ProductCard({ ...product }: Product) {
         {image !== "" ? (
           <>
             <Image src={image} alt={product.name} fill />
-            <ProductActionsBar productId={product.id} />
+            {hasEditPerms && <ProductActionsBar productId={product.id} />}
           </>
         ) : (
           <Spinner size={40} color="black" />

--- a/components/products/ProductsWrapper.tsx
+++ b/components/products/ProductsWrapper.tsx
@@ -1,13 +1,17 @@
 import ProductCard from "./ProductCard";
+import { getUserRole } from "@/lib/actions/helpers/encodeUserCredentials";
 
 interface ProductsWrapperProps {
   products: Product[] | null;
 }
 
-export default function ProductsWrapper({ products }: ProductsWrapperProps) {
+export default async function ProductsWrapper({ products }: ProductsWrapperProps) {
+  const role = await getUserRole();  
+  const hasEditPerms = role === "Admin" || role === "Employee";
+
   return (
     <div className="mt-10 flex w-full flex-wrap items-center justify-center gap-x-10">
-      {products && products.map((product) => <ProductCard key={product.id} {...product} />)}
+      {products && products.map((product) => <ProductCard key={product.id} hasEditPerms={hasEditPerms} {...product} />)}
     </div>
   );
 }

--- a/lib/actions/helpers/encodeUserCredentials.ts
+++ b/lib/actions/helpers/encodeUserCredentials.ts
@@ -1,0 +1,29 @@
+"use server";
+
+import { cookies } from "next/headers";
+
+
+export async function encodeUserCredentials(creds: User) {
+    const stringifiedInfo = JSON.stringify(creds);
+    const encodedInfo = Buffer.from(stringifiedInfo, "utf-8").toString('base64');
+
+    cookies().set("e_creds", encodedInfo);
+}
+
+export async function decodeUserCredentials(creds: string) {
+    const decodedInfo = Buffer.from(creds, "base64").toString("utf-8");
+
+    return JSON.parse(decodedInfo) as User;
+}
+
+export async function getUserRole() {
+    const creds = cookies().get("e_creds")?.value;
+    
+    
+    if (!creds) {
+        return null;
+    }
+
+    const dCreds = await decodeUserCredentials(creds);
+    return dCreds.role.name;
+}


### PR DESCRIPTION
Added:
- Started storing user credentials in a base64 encoded format in cookies to cut down the API calls for constant check of the user's role.